### PR TITLE
Fix overflow of SpawnFest nav logo

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -322,6 +322,7 @@ a.btn-previous-edition:focus {
     padding: 2px 4px;
 }
 #mainNav {
+    padding-top: 0;
     padding-right: 0;
     padding-left: 0;
 }
@@ -398,8 +399,8 @@ a.btn-previous-edition:focus {
     
     #mainNav .nav-title {
         height: 65px;
-        margin-top: -33px;
-        margin-bottom: -33px;
+        margin-top: -10px;
+        margin-bottom: -10px;
     }
 }
 header.masthead {


### PR DESCRIPTION

This commit fixes an overflow problem where by on desktop browsers when scrolling the SpawnFest nav logo would get cut off.
It also fixes an issue where on mobile there was extra space between the navbar and sections when scrolling.

 - Add a default padding-top to the nav bar of 0
 - Adjusting margin offsets for nav logo


Desktop Before:


<img width="599" alt="Screen Shot 2021-04-25 at 11 48 26 AM" src="https://user-images.githubusercontent.com/39971740/116001822-25b53780-a5bc-11eb-91ca-30aa414d1429.png">


Desktop After:

<img width="374" alt="Screen Shot 2021-04-25 at 11 49 00 AM" src="https://user-images.githubusercontent.com/39971740/116001831-3b2a6180-a5bc-11eb-981b-f031d0df3be2.png">


Mobile before: 

<img width="331" alt="Screen Shot 2021-04-25 at 11 50 07 AM" src="https://user-images.githubusercontent.com/39971740/116001856-6319c500-a5bc-11eb-821f-ab696abebb16.png">


Mobile after:

<img width="319" alt="Screen Shot 2021-04-25 at 11 50 40 AM" src="https://user-images.githubusercontent.com/39971740/116001873-7593fe80-a5bc-11eb-9042-70fbe21e4def.png">

