### PR TITLE
Switch back to italic element for rule icons

### DIFF
--- a/_includes/rules.html
+++ b/_includes/rules.html
@@ -10,7 +10,7 @@
         {% for rule in site.rules %}
           <li>
             <div class="rule-icon">
-              <em class="icon {{ rule.icon }}"></em>
+              <i class="icon {{ rule.icon }}"></i>
             </div>
             <div class="rule border">
               <div class="rule-title"><strong>{{ rule.title }}</strong></div>


### PR DESCRIPTION

 This commit reverts a change where switched from using `i` element for rule icons to `em` elements.
However, Using `em` or `span` currently breaks the design in the rules section.


Currently deployed :
<img width="984" alt="Screen Shot 2021-04-27 at 7 15 27 PM" src="https://user-images.githubusercontent.com/39971740/116327667-eee24b80-a78c-11eb-97b5-2e9edf439363.png">

After switching back to italitcs: 
<img width="1117" alt="Screen Shot 2021-04-27 at 7 16 28 PM" src="https://user-images.githubusercontent.com/39971740/116327746-133e2800-a78d-11eb-8508-df6e2d61fb85.png">


We can definitely make spans work, but we should circle back and get this fix out first. 
