### PR TITLE
Adjust for accessibility

### DIFF
--- a/_includes/rules.html
+++ b/_includes/rules.html
@@ -10,7 +10,7 @@
         {% for rule in site.rules %}
           <li>
             <div class="rule-icon">
-              <i class="icon {{ rule.icon }}"></i>
+              <em class="icon {{ rule.icon }}"></em>
             </div>
             <div class="rule border">
               <div class="rule-title"><strong>{{ rule.title }}</strong></div>

--- a/css/style.css
+++ b/css/style.css
@@ -181,7 +181,7 @@ section#rules {
     text-align: center;
 }
 
-.rule-icon i {
+.rule-icon em {
     padding: 10px;
     border: 2px solid black!important;
     border-radius: 10%;


### PR DESCRIPTION
Let me know if this works better. "`<i>` for `<em>`" is for accessibility purposes.

**Edit**: it looks OK on my end.