### PR TITLE
Remove some of the previous ideias

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -166,12 +166,8 @@ ideas:
   - title: Native secrets library for projects
     description: A tool to allow storing secrets in Git (or another CVS) with minimal configuration effort, native to BEAM
     (from https://github.com/elasticdog/transcrypt: configure transparent encryption of sensitive files stored in a Git repository)
-  - title: Erlang Markdown lib
-    description: An Erlang library that provides parsing and rendering of Markdown (common, GFM, etc.)
   - title: Pretty diff support for common tests
     description: A library that provides assertions which produce pretty diffs a la ExUnit on match and comparison assertions.
-  - title: OS certificate authority library
-    description: A library to access certificate bundles from the operating system rather than having to carry them with the application.
   - title: Recurring event site
     description: A website to organize recurring events (in the style of Meetup but for stuff that happens every week). I'm thinking about... say... a group of friends that gather every week in the same place to play soccer, watch movies, read books, or hike.
   - title: A public sports field status tracker app/website.
@@ -198,8 +194,6 @@ ideas:
     description: We have <a target="_blank" href="https://github.com/inaka/elvis">Elvis</a> which will show places where we can improve our code, but it won't fix them. It would be cool to go one step further and build something to apply changes to our code to improve it.
   - title: Process Mocker
     description: <a target="_blank" href="https://hex.pm/packages/meck">Meck</a> allows you to mock modules and functions. A similar tool that would allow you to mock processes (i.e. step between a registered process and its callers and mock its behavior, passthrough others, count messages received, etc) would be great.
-  - title: a CI-oriented lib.
-    description: a lib. that concentrates good CI practices (testing, analysis, etc.) with an easy way to spawn other lib.s by a template it defines (or maybe a rebar3 plugin?)
   - title: copyright-header creator/updater
     description: a copyright-header-creator lib. (add an easy copyright - or update an existing one - to all your source files) - might have to deal with parse_trans or regexp
   - title: Some Application


### PR DESCRIPTION
1. Erlang Markdown lib (touched in SpawnFest 2021)
2. OS Certificates (are being implemented in Erlang/OTP directly)
3. CI-oriented lib. (there're quite a few new rebar3 plugins and examples to get inspired from)