### PR TITLE
Tweak a bit of the display constraints

### DIFF
--- a/_includes/sponsors.html
+++ b/_includes/sponsors.html
@@ -26,8 +26,8 @@
           <a class="sponsor sponsor-platinum-a col-md-6 col-sm-12" href="{{ sponsor.url }}">
               <div class="rounded mx-auto text-center sponsor sponsor-platinum ">
                   <img class=" p-2 " src="/img/{{ sponsor.logo }} " alt="{{ sponsor.name }} ">
+                  <p>(for bracket {{ sponsor.bracket_name }} )</p>
               </div>
-              <p>(for bracket {{ sponsor.bracket_name }} )</p>
           </a>
           {% endif %}
         {% endfor %}
@@ -50,8 +50,8 @@
           <a class="sponsor sponsor-gold-a col-md-4 col-sm-12" href="{{ sponsor.url }}">
               <div class="rounded mx-auto text-center sponsor sponsor-gold ">
                   <img class=" p-2 " src="/img/{{ sponsor.logo }} " alt="{{ sponsor.name }} ">
+                  <p>(for bracket {{ sponsor.bracket_name }} )</p>
               </div>
-              <p>(for bracket {{ sponsor.bracket_name }} )</p>
           </a>
           {% endif %}
         {% endfor %}
@@ -74,8 +74,8 @@
           <a class="sponsor sponsor-silver-a col-md-3 col-sm-12" href="{{ sponsor.url }}">
               <div class="rounded mx-auto text-center sponsor sponsor-silver ">
                   <img class=" p-2 " src="/img/{{ sponsor.logo }} " alt="{{ sponsor.name }} ">
+                  <p>(for bracket {{ sponsor.bracket_name }} )</p>
               </div>
-              <p>(for bracket {{ sponsor.bracket_name }} )</p>
           </a>
           {% endif %}
         {% endfor %}
@@ -98,8 +98,8 @@
           <a class="sponsor sponsor-bronze-a col-md-3 col-sm-12" href="{{ sponsor.url }}">
               <div class="rounded mx-auto text-center sponsor sponsor-bronze ">
                   <img class=" p-2 " src="/img/{{ sponsor.logo }} " alt="{{ sponsor.name }} ">
+                  <p>(for bracket {{ sponsor.bracket_name }} )</p>
               </div>
-              <p>(for bracket {{ sponsor.bracket_name }} )</p>
           </a>
           {% endif %}
         {% endfor %}

--- a/css/style.css
+++ b/css/style.css
@@ -265,6 +265,7 @@ a.style {
 .organizer,
 .organizer:hover {
     color: black;
+    text-decoration: none;
 }
 
 #sponsors{
@@ -284,12 +285,11 @@ a.style {
 }
 
 .sponsors-container a {
-    padding-bottom: 225px;
+    margin-bottom: 70px;
 }
 
 .sponsor {
     height: 60px;
-    display: flex;
     justify-content: center;
     align-items: center;
 }
@@ -305,7 +305,7 @@ a.style {
 
 .sponsor-gold,
 .sponsor-gold-a {
-    height: 125px;
+    height: 100px;
 }
 
 .sponsor-silver, 


### PR DESCRIPTION
1. make gold sponsors have approximate sizes (for consistency)
2. make "(for bracket ...)" be part of the sponsor link
3. remove _ (underline) from organisers' link
4. use margin instead of padding (where it's due)