### PR TITLE
Fix redirects to previous editions' websites

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -32,9 +32,9 @@
         <h2>Previous editions</h2>
         <p>Check what happened in our previous editions:</p>
         <div class="pl-2">
-          <a class="text-white btn btn-previous-edition btn-sm p-2 m-1" href="https://spawnfest.github.io/2011/index.html">2011</a>
-          <a class="text-white btn btn-previous-edition btn-sm p-2 m-1" href="https://spawnfest.github.io/2012/index.html">2012</a>
-          <a class="text-white btn btn-previous-edition btn-sm p-2 m-1" href="https://spawnfest.github.io/2017/index.html">2017</a>
+          <a class="text-white btn btn-previous-edition btn-sm p-2 m-1" href="/legacy/2011">2011</a>
+          <a class="text-white btn btn-previous-edition btn-sm p-2 m-1" href="/legacy/2012">2012</a>
+          <a class="text-white btn btn-previous-edition btn-sm p-2 m-1" href="/legacy/2017">2017</a>
           <a class="text-white btn btn-previous-edition btn-sm p-2 m-1" href="/legacy/2018">2018</a>
           <a class="text-white btn btn-previous-edition btn-sm p-2 m-1" href="/legacy/2019">2019</a>
           <a class="text-white btn btn-previous-edition btn-sm p-2 m-1" href="/legacy/2020">2020</a>


### PR DESCRIPTION
Those GitHub pages happen to be down. Since old websites are on the filesystem, we can simply refer to them like so.