### PR TITLE
Make "competition is over" visible

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ nav:
 # We move by flags, one phase at a time (these are ordered)
 before_countdown_to_start: false  # countdown to start of competition is in effect
 before_registration_is_over: false  # players and sponsor can no longer apply
-before_competition_is_over: true  # while competition is ongoing
+before_competition_is_over: false  # while competition is ongoing
 before_votes_are_out: true  # while judges are doing their thing
 
 last_edition_year: 2022


### PR DESCRIPTION
In preparation for post-competition (⚠️ merge on Sunday, at 23:59, as per rules).